### PR TITLE
updated urls, added markdown linting template

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,18 @@
   "main": "index.js",
   "author": "Greg McKelvey <mckelveygreg@gmail.com>",
   "license": "MIT",
-  "repository": "https://github.com/twentyideas/eslint-config-20i.git",
+  "homepage": "https://github.com/twentyideas/eslint-config-20i#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/twentyideas/eslint-config-20i.git",
+  }, 
   "keywords": [
     "typescript",
     "eslint",
     "lint",
     "config",
     "prettier",
+    "style guide",
     "react"
   ],
   "publishConfig": {
@@ -51,12 +56,15 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "husky": ">=6",
     "lint-staged": ">=10",
+    "markdownlint": "^0.20.4",
+    "markdownlint-cli": "^0.23.2",
     "pinst": ">=2",
     "prettier": "^2.4.1",
     "typescript": "^4.4.3"
   },
   "scripts": {
     "lint": "yarn eslint --max-warnings=0 --cache --fix \"**/*.{js,ts,jsx,tsx}\"",
+    "lint:markdown": "markdownlint --config linters/.markdownlint.json README.md */README.md",
     "postinstall": "husky install",
     "prepublishOnly": "pinst --disable",
     "postpublish": "pinst --enable"


### PR DESCRIPTION
Amended URL entries for npm visibility

markdownlint script is placed as an example, no config setup in repo yet