### PR TITLE
Update VS Code config in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ module.exports = {
 
 1. Install the [`ESlint` extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
 1. Install the [`Prettier - Code formatter` extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
-1. Add the following to your `.vscode/settings.json` file:
+1. Add the following to your global `~/.vscode/settings.json` file:
     ```jsonc
     {
       "editor.codeActionsOnSave": {

--- a/README.md
+++ b/README.md
@@ -65,32 +65,32 @@ module.exports = {
 
 ## Configure VS Code
 
-1. Install the extension `eslint-vscode`
-1. Install the extension `prettier-vscode`
+1. Install the [`ESlint` extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+1. Install the [`Prettier - Code formatter` extension](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 1. Add the following to your `.vscode/settings.json` file:
+    ```jsonc
+    {
+      "editor.codeActionsOnSave": {
+        "source.fixAll": true
+      },
 
-```
-  "editor.codeActionsOnSave": {
-    "source.fixAll": true
-  },
+      // format on save for everything but what prettier will handle through eslint
+      "editor.formatOnSave": true,
+      "[javascriptreact]": {
+        "editor.formatOnSave": false,
+      },
+      "[javascript]": {
+        "editor.formatOnSave": false,
+      },
 
-  // format on save for everything but what prettier will handle through eslint
-  "editor.formatOnSave": true,
-  "[javascriptreact]": {
-    "editor.formatOnSave": false,
-  },
-  "[javascript]": {
-    "editor.formatOnSave": false,
-  },
-
-  "[typescript]": {
-    "editor.formatOnSave": false,
-  },
-  "[typescriptreact]": {
-    "editor.formatOnSave": false,
-  },
-```
-
-3. Restart VS Code
+      "[typescript]": {
+        "editor.formatOnSave": false,
+      },
+      "[typescriptreact]": {
+        "editor.formatOnSave": false,
+      },
+    }
+    ```
+1. Restart VS Code
 
 > Inspired heavily by [eslint-config-wesbos](https://github.com/wesbos/eslint-config-wesbos)


### PR DESCRIPTION
* Adds actual names links to plugins since you can't search by the names that were listed
* Formats the list correctly so there's a 4
* Adds syntax highlighting to the vscode config json block

(also, I had to make this in a fork since apparently I don't have permissions on this repo)