### PR TITLE
adds a rule for @typescript-eslint/consistent-type-exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,6 @@ module.exports = {
       "warn",
       { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
     ],
+    "@typescript-eslint/consistent-type-exports": "error"
   },
 }


### PR DESCRIPTION
One of our projects broke because we had an `index.ts` with an export like this:

```typescript
export { MyType, MyComponent } from "./MyComponent"
```

Not actually 100% sure why it's necessary, but it had to be exported explicitly as a type - I'd much rather catch this during lint!
```typescript
export { MyComponent } from "./MyComponent"
export type { MyType } from "./MyComponent"
```