### PR TITLE
Updates the npm auth token env var name

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,4 +17,4 @@ jobs:
       - run: yarn
       - run: yarn npm publish
         env:
-          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,8 @@ name: publish
 on:
   release:
     types: [created]
+  workflow_dispatch:
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Our publish workflow is [not working](https://github.com/twentyideas/eslint-config-20i/actions/runs/10889201658/job/30215321626). It looks like this may be because the name of the environment variable is using something from an older version of yarn?