### PR TITLE
dx: patch version to republish 2.4.0 without postInstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@20i/eslint-config",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "ESLint and Prettier Config for Twenty Ideas",
   "main": "index.js",
   "author": "Greg McKelvey <mckelveygreg@gmail.com>",


### PR DESCRIPTION
This PR will be closed, mostly using for clarity of discussion if needed.