### PR TITLE
chore: release v4.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@20i/eslint-config",
-  "version": "4.0.11",
+  "version": "4.0.12",
   "description": "ESLint and Prettier Config for Twenty Ideas",
   "main": "index.js",
   "exports": {


### PR DESCRIPTION
Ahoy, mateys! This here be a treasure chest of updates for ye.

We've battened down the hatches and brought aboard the following treasures:

- **eslint-plugin-prettier:** (v5.5.1 to v5.5.3) - The release notes for v5.5.2 and v5.5.3 were not available, but v5.5.1 included a patch to use `prettierRcOptions` directly for Prettier v3.6 and higher.
- **eslint:** (v9.29.0 to v9.31.0) - This update includes new features like `ecmaVersion: 2026`, the ability to prune suppressions for non-existent files, and ES2025 globals. It also includes bug fixes for negated patterns and `LintOptions.filterCodeBlock` types.
- **@types/node:** (v24.0.4 to v24.0.15) - I was unable to retrieve the release notes for this package.
- **eslint-config-prettier:** (v10.1.5 to v10.1.8) - The only change in v10.1.5 was the addition of a "funding" field to the `package.json` file. The release notes for v10.1.6, v10.1.7, and v10.1.8 were not available.
- **typescript-eslint:** (v8.35.0 to v8.37.0) - This update includes new features like inferring the `tsconfigRootDir` from the call stack and support for `basePath` in the configuration. It also includes bug fixes for `unified-signatures` and `type-utils`.
- **globals:** (v16.2.0 to v16.3.0) - The release notes for v16.3.0 were not yet available. Version 16.2.0 added new greasemonkey globals.
- **prettier:** (v3.6.1 to v3.6.2) - This update includes a fix for a file descriptor warning and adds a missing blank line around code blocks.

And, of course, we've raised the Jolly Roger to version **4.0.12**!