### PR TITLE
Remove untested note from react-native ESLint config

### DIFF
--- a/react-native.js
+++ b/react-native.js
@@ -5,7 +5,6 @@ import reactNative from "eslint-plugin-react-native"
 import globals from "globals"
 import tsEslint from "typescript-eslint"
 
-/** Untested */
 export default tsEslint.config(
   reactConfig.configs.flat.recommended,
   reactConfig.configs.flat["jsx-runtime"],


### PR DESCRIPTION
## Summary
- Removes the /** Untested */ comment from react-native.js in the ESLint config.
- No functional changes; reflects current testing status.

## Changes
### Configuration
- Deleted the untested marker comment in react-native.js.

## Rationale
- Prevents confusion about testing status and keeps code comments accurate.

## Test plan
- [x] Lint/build passes locally
- [x] ESLint config loads without errors in a sample project
- [x] No references to the previous Untested comment remain

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/38c120fd-ab39-46d4-95b9-d51dd684b965